### PR TITLE
Downstream

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ pandas
 numpy
 seaborn
 plotly
-cadCAD
+cadCAD @ git+https://github.com/cadCAD-org/cadCAD@740320910bb5db428404875a87895e38f0a05614
 scikit-learn
 scikit-image

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ numpy
 seaborn
 plotly
 cadCAD
-sklearn
+scikit-learn
 scikit-image


### PR DESCRIPTION
This package has a compatibility issue with python 3.10 or greater. The fix here adjust the faulty issues. Because cadCAD package itself hasn't cut a new release the git commit is required to  point to a stable working version for python 3.10 > .  Additionally there is a sci kit dependency that needed to be updated as sklearn was deprecated